### PR TITLE
correct dead loop when decode level 6 and above h264 stream

### DIFF
--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_dec.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_dec.h
@@ -89,11 +89,7 @@ public:
         H264_LEVEL_61   = 61,
         H264_LEVEL_62   = 62,
 
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
         H264_LEVEL_MAX  = 62,
-#else
-        H264_LEVEL_MAX  = 52,
-#endif
 
         H264_LEVEL_9    = 9  // for SVC profiles
     };

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -795,7 +795,7 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         case H264VideoDecoderParams::H264_LEVEL_6:
         case H264VideoDecoderParams::H264_LEVEL_61:
         case H264VideoDecoderParams::H264_LEVEL_62:
-            level_idc = H264VideoDecoderParams::H264_LEVEL_MAX;
+            level_idc = INTERNAL_MAX_LEVEL;
             break;
         default:
             throw h264_exception(UMC_ERR_FAILED);

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_task_supplier.h
@@ -724,13 +724,11 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         case H264VideoDecoderParams::H264_LEVEL_52:
             MaxDPBMbs = 184320;
             break;
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
         case H264VideoDecoderParams::H264_LEVEL_6:
         case H264VideoDecoderParams::H264_LEVEL_61:
         case H264VideoDecoderParams::H264_LEVEL_62:
             MaxDPBMbs = 696320;
             break;
-#endif
         default:
             // We don't support level greater than 5.2 but
             // relax resolution constrains up to 4K, hence
@@ -792,15 +790,13 @@ inline int32_t CalculateDPBSize(uint8_t & level_idc, int32_t width, int32_t heig
         // can be used to calculate the DPB size.
         case H264VideoDecoderParams::H264_LEVEL_51:
         case H264VideoDecoderParams::H264_LEVEL_52:
-            level_idc = H264VideoDecoderParams::H264_LEVEL_52;
+            level_idc = H264VideoDecoderParams::H264_LEVEL_6;
             break;
-#if (MFX_VERSION >= MFX_VERSION_NEXT)
         case H264VideoDecoderParams::H264_LEVEL_6:
         case H264VideoDecoderParams::H264_LEVEL_61:
         case H264VideoDecoderParams::H264_LEVEL_62:
             level_idc = H264VideoDecoderParams::H264_LEVEL_MAX;
             break;
-#endif
         default:
             throw h264_exception(UMC_ERR_FAILED);
         }


### PR DESCRIPTION
when decoding a level 6 or above h264 stream, there may be a dead loop.